### PR TITLE
Remove task list check from required status check list

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -38,8 +38,7 @@ orgs.newOrg('eclipse-ankaios') {
             "Build Linux arm64",
             "Build requirements tracing",
             "Deploy documentation",
-            "Check if documentation has changed",
-            "Verify PR Task List",
+            "Check if documentation has changed"
           ],
           requires_conversation_resolution: true,
         },


### PR DESCRIPTION
Because of technical limitations in GH in combination with the task list checker GH Action we decided to remove it.