### PR TITLE
fix: remove old commit branch protection rules

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -117,9 +117,6 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
         "containers",
         "orchestration"
       ],
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main'),
-      ],
       web_commit_signoff_required: false,
       rulesets: [
         orgs.newRepoRuleset('main_release_protection') {


### PR DESCRIPTION
Related to: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5727#note_3330617

And this PR: https://github.com/eclipse-ankaios/.eclipsefdn/pull/1