### PR TITLE
Remove double branch protection rule

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -117,11 +117,6 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
         "containers",
         "orchestration"
       ],
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 1,
-        },
-      ],
       web_commit_signoff_required: false,
       rulesets: [
         orgs.newRepoRuleset('main_release_protection') {


### PR DESCRIPTION
The PR removes the double branch protection rule introduced with #16 

More details on the topic can also be found here: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5727