### PR TITLE
Allow deployments also for tags in ank-sdk-python

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -50,7 +50,8 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "main"
+            "main",
+            "tag:v[0-9].[0-9].[0.9]"
           ],
           deployment_branch_policy: "selected",
         },

--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -51,7 +51,7 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
             "main",
-            "tag:v[0-9].[0-9].[0.9]"
+            "tag:v*"
           ],
           deployment_branch_policy: "selected",
         },


### PR DESCRIPTION
This PR allows deployments to Github pages also for tags in the ank-sdk-python repo.