### PR TITLE
Remove branch protection for feature branches

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -124,8 +124,7 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
           allows_creations: true,
           include_refs+: [
             "refs/heads/release-**",
-            "~DEFAULT_BRANCH",
-            "refs/heads/feature/**"
+            "~DEFAULT_BRANCH"
           ],
           required_pull_request+: {
             required_approving_review_count: 1,


### PR DESCRIPTION
We need to commit to the branch directly in order to update with main:
https://github.com/eclipse-ankaios/ankaios/pull/610
As visible the commit gets messed up because the history is broken when you merge through a third branch.

We will create a new branch protection with a limited scope, but for now we need to get the PR in a workable state.