### PR TITLE
Create rule for feature branch protection

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -163,11 +163,7 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
             ],
           },
           bypass_actors+: [
-            {
-              actor_type: 'Team',
-              actor_id: 7841090,
-              bypass_mode: 'always'
-            }
+            "@eclipse-ankaios/automotive-ankaios-project-leads",
           ]
         },
       ],

--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -143,6 +143,33 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
             ],
           },
         },
+        orgs.newRepoRuleset('feature_branch_protection') {
+          allows_creations: true,
+          include_refs+: ["refs/heads/feature-**"],
+          required_pull_request+: {
+            required_approving_review_count: 1,
+            requires_review_thread_resolution: true,
+          },
+          required_status_checks+: {
+            do_not_enforce_on_create: true,
+            status_checks+: [
+              "Build Linux amd64 debian package",
+              "Build Linux arm64 debian package",
+              "Build and run system tests Linux amd64",
+              "Build requirements tracing",
+              "Check if documentation has changed",
+              "Deploy documentation",
+              "Run unit tests Linux amd64"
+            ],
+          },
+          bypass_actors+: [
+            {
+              actor_type: 'Team',
+              actor_id: 7841090,
+              bypass_mode: 'always'
+            }
+          ]
+        },
       ],
       environments: [
         orgs.newEnvironment('github-pages') {


### PR DESCRIPTION
## Description

The feature protection rule cannot be part of the main release one, so a new rule must be devised unique to the feature branches.

This PR adds a new rule for the feature branch protection, incorporating the same checks and permissions as the main release one, with one key difference: the [`automotive-ankaios-project-leads`](https://github.com/orgs/eclipse-ankaios/teams/automotive-ankaios-project-leads) team can bypass it.