### PR TITLE
Add new meta-ankaios repo for yocto layers and examples

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -231,6 +231,19 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
 } + {
   # snippet added due to 'https://github.com/EclipseFdn/otterdog-configs/blob/main/blueprints/add-dot-github-repo.yml'
   _repositories+:: [
-    orgs.newRepo('.github')
+    orgs.newRepo('.github') {
+      rulesets: [
+        orgs.newRepoRuleset('main_protection') {
+          allows_creations: true,
+          include_refs+: [
+            "~DEFAULT_BRANCH"
+          ],
+          required_pull_request+: {
+            required_approving_review_count: 1,
+            requires_review_thread_resolution: true,
+          },
+        },
+      ],
+    }
   ],
 }

--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -191,6 +191,40 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
         },
       ],
     },
+    orgs.newRepo('meta-ankaios') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      description: "Yocto example and metadata layer for binary installation of Eclipse Ankaios",
+      topics+: [
+        "ankaios",
+        "automotive",
+        "iot",
+        "containers",
+        "orchestration",
+        "yocto",
+        "embedded-linux"
+      ],
+      web_commit_signoff_required: false,
+      rulesets: [
+        orgs.newRepoRuleset('main_protection') {
+          allows_creations: true,
+          include_refs+: [
+            "~DEFAULT_BRANCH"
+          ],
+          required_pull_request+: {
+            required_approving_review_count: 1,
+            requires_review_thread_resolution: true,
+          },
+          required_status_checks+: {
+            do_not_enforce_on_create: true,
+            status_checks+: [
+              "Lint recipes"
+            ],
+          },
+        },
+      ],
+    },
   ],
 } + {
   # snippet added due to 'https://github.com/EclipseFdn/otterdog-configs/blob/main/blueprints/add-dot-github-repo.yml'

--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -130,8 +130,10 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
       topics+: [
         "ankaios",
         "automotive",
+        "iot",
         "containers",
-        "orchestration"
+        "orchestration",
+        "rust"
       ],
       web_commit_signoff_required: false,
       rulesets: [


### PR DESCRIPTION
This PR adds a new meta-ankaios repo that will hold yocto layers and examples.

Additionally I added some topics to the main Ankaios repo and a branch protection rule to the .github repo (for improved security)