### PR TITLE
Add SONAR_TOKEN secret to the SDK repositories

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -72,6 +72,11 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
         },
         orgs.newEnvironment('pypi'),
       ],
+      secrets: [
+        orgs.newRepoSecret('SONAR_TOKEN') {
+          value: "pass:bots/automotive.ankaios/sonarcloud.io/token-ankaios",
+        },
+      ],
     },
     orgs.newRepo('ank-sdk-rust') {
       allow_merge_commit: true,
@@ -113,6 +118,11 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
             "gh-pages"
           ],
           deployment_branch_policy: "selected",
+        },
+      ],
+      secrets: [
+        orgs.newRepoSecret('SONAR_TOKEN') {
+          value: "pass:bots/automotive.ankaios/sonarcloud.io/token-ankaios",
         },
       ],
     },


### PR DESCRIPTION
# Description

The SONAR_TOKEN was added in the main repository, but if we are to add the SDKs to the SonarQube, we need the token to be available in the SDKs as well.