### PR TITLE
Fix required checks for meta-ankaios

### DIFF
--- a/otterdog/eclipse-ankaios.jsonnet
+++ b/otterdog/eclipse-ankaios.jsonnet
@@ -226,7 +226,7 @@ orgs.newOrg('automotive.ankaios', 'eclipse-ankaios') {
           required_status_checks+: {
             do_not_enforce_on_create: true,
             status_checks+: [
-              "Lint recipes / Recipe lint"
+              "Recipe lint"
             ],
           },
         },


### PR DESCRIPTION
Rename expected action. It should only contain the job-name, without the workflow-name.
